### PR TITLE
Docker networks might differ depending on the env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ clean-kindev: ## Clean kindev
 	make clean
 
 push-golden: DEBUG=true
+push-golden: HOST=$(shell docker inspect kindev-control-plane | jq '.[0].NetworkSettings.Networks.kind.Gateway')
 push-golden: ## Push AppCat configuration converged mode to local forgejo. By default it will try to connect to AppCat running in debug mode. Use `-e DEBUG=false` to run against containers in the cluster
 	yq '.parameters.appcat.proxyFunction |= $(DEBUG)' component-appcat/tests/dev.yml | diff -B component-appcat/tests/dev.yml - | patch component-appcat/tests/dev.yml -
+	yq '.parameters.appcat.grpcEndpoint |= $(HOST)' component-appcat/tests/dev.yml | diff -B component-appcat/tests/dev.yml - | patch component-appcat/tests/dev.yml -
 	cd component-appcat && \
 	make push-golden
 


### PR DESCRIPTION
This change will automatically figure out the correct IP address for the GRPC proxy. Sometimes Docker's netowrking might not always assign the same network. To combat that, we will now automatically inject the right host into the `dev.yaml` configuration.