### PR TITLE
Update to go 1.25

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:dev-1.24-bookworm
+FROM mcr.microsoft.com/devcontainers/go:dev-1.25-bookworm
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
     },
     "ghcr.io/mikaello/devcontainer-features/modern-shell-utils:2.0.0": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-      "minikube": "none"
+      "minikube": "none",
+      "helm": "v3.19.2"
     },
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
       "yqVersion": "latest"


### PR DESCRIPTION
This commit also pins the helm version as a few days ago Helm 4.0.0 was released with a bunch of breaking changes that break the devcontainer.